### PR TITLE
[Cumulus 802] Capture SIGTERM

### DIFF
--- a/bin/service.js
+++ b/bin/service.js
@@ -110,3 +110,7 @@ process.on('SIGINT', () => {
   rimraf.sync(argv.workDirectory);
   process.exit();
 });
+
+process.on('SIGTERM', () => {
+  log.info('Received SIGTERM, ignoring signal and continuing with task...');
+});


### PR DESCRIPTION
This PR captures SIGTERM which could be sent by ECS autoscaling services or EC2 instances and ignores it. Eventually, SIGKILL will kill the task but the period which the ECS Agent waits to send SIGKILL is being extended in https://github.com/nasa/cumulus/pull/868/commits/8a23c4bb36b786508974eed612a95f3b5d22da0b

Testing:
* Locally, ran:
```
npm start -- \
   --activityArn arn:aws:states:us-east-1:XXX:activity:aimee-HelloWorld-Activity \
   --lambdaArn arn:aws:lambda:us-east-1:XXX:function:aimee-HelloWorld
```
Kick off the HelloWorld workflow, wait for task to get picked up, 
```bash
kill <node process pid>
```
* Without the process.on('SIGTERM') the process exits immediately.
* With the process.on('SIGTERM') I was able to verify the log message and task keeps running.

The behavior when run with docker was slightly different: With and without the process.on('SIGTERM') block, docker waited a certain amount of time (defaults to 10s, configurable with the `--time` flag) for the container to exit before sending the `SIGKILL`. See [docker stop](https://docs.docker.com/engine/reference/commandline/stop/).

Given the [StopTask](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_StopTask.html) documentation, it seems like this catch should work, but I'm going to move forward with the following test plan.

Test plan:
Push a new tagged version to dockerhub and update the task definition version used in https://github.com/nasa/cumulus/pull/868. Stop the running task by (not simultaneously, in separate tests):
1. Setting desired instances of the ASG to 0
2. Setting desired services of the task to 0
3. Check in both cases the tasks exit 0 after the hello world run time (e.g. sleeping for 120 seconds)