### PR TITLE
Cumulus 1629 remove python2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### BREAKING CHANGES
 
 - **CUMULUS-1629**
-  - Remove install of python 2 from cumulus-ecs-image.
+  - Update image python to python3.
 
 ## [v1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v1.5.0]
+
+### BREAKING CHANGES
+
+- **CUMULUS-1629**
+  - Remove install of python 2 from cumulus-ecs-image.
+
 ## [v1.4.0]
 
 ### Changed
@@ -89,9 +96,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 - Initial release
-
-[Unreleased]: https://github.com/nasa/cumulus-ecs-task/compare/v1.4.0...HEAD
-[v1.4.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.3.0...1.4.0
+[Unreleased]: https://github.com/nasa/cumulus-ecs-task/compare/v1.5.0...HEAD
+[v1.5.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.4.0...v1.5.0
+[v1.4.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.3.0...v1.4.0
 [v1.3.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.2.5...v1.3.0
 [v1.2.5]: https://github.com/nasa/cumulus-ecs-task/compare/v1.2.4...v1.2.5
 [v1.1.2]: https://github.com/nasa/cumulus-ecs-task/compare/v1.1.2...v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### BREAKING CHANGES
 
 - **CUMULUS-1629**
-  - Update image python to python3.
+  - Update image python to python3.   This version of cumulus-ecs-task is *required* for CMA >= 1.2.0.
 
 ## [v1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### BREAKING CHANGES
 
 - **CUMULUS-1629**
-  - Update image python to python3.   This version of cumulus-ecs-task is *required* for CMA >= 1.2.0.
+  - Update image python to python3.   This version of cumulus-ecs-task is *required* for [Cumulus message adapter](https://github.com/nasa/cumulus-message-adapter) >= 1.2.0.
 
 ## [v1.4.0]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN npm install -g npm@latest
 
 RUN apk update && \
   apk add unzip && \
-  apk add python2 && \
   rm -rf /var/cache/apk
 
 RUN addgroup -S -g 433 service

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN npm install -g npm@latest
 
 RUN apk update && \
   apk add unzip && \
+  apk add python3 && \
+  ln -s /usr/bin/python3.7 /usr/bin/python && \
   rm -rf /var/cache/apk
 
 RUN addgroup -S -g 433 service

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Run lambda functions in ECS",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This update updates system python from 2-3.7 to support CMA > 1.2.0 moving forward. 