### PR TITLE
CUMULUS-3094: Updated the unzip command with -q option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **CUMULUS-3094**
+  - Updated the unzip command with -q option to prevent listing files to stdout
+
 ## [v1.9.0]
 
 ### BREAKING CHANGES

--- a/index.js
+++ b/index.js
@@ -166,8 +166,8 @@ function setCumulusMessageAdapterPath(taskDir, layerDir) {
 **/
 async function installLambdaFunction(lambdaArn, workDir, taskDir, layerDir) {
   const resp = await getLambdaSource(lambdaArn, workDir, layerDir);
-  const unzipPromises = resp.layerPaths.map((layerFilePath) => execPromise(`unzip -o ${layerFilePath} -d ${layerDir}`));
-  unzipPromises.push(execPromise(`unzip -o ${resp.filepath} -d ${taskDir}`));
+  const unzipPromises = resp.layerPaths.map((layerFilePath) => execPromise(`unzip -q -o ${layerFilePath} -d ${layerDir}`));
+  unzipPromises.push(execPromise(`unzip -q -o ${resp.filepath} -d ${taskDir}`));
   await Promise.all(unzipPromises);
 
   setCumulusMessageAdapterPath(taskDir, layerDir);


### PR DESCRIPTION
I used the following commands (from README) to test the fixes:
```
npm run build
docker run -e AWS_ACCESS_KEY_ID='xxx' -e AWS_SECRET_ACCESS_KEY='xxx' cumuluss/cumulus-ecs-task --activityArn  "arn:aws:states:us-east-1:1234:activity:prefix-EcsTaskHelloWorld" --lambdaArn "arn:aws:lambda:us-east-1:1234:function:prefix-HelloWorld"
```

Update the lambda function with a lambda.zip contains lots of files (I added node_modules directory to the lambda.zip).
Reproduce the issue with master branch
Test the fix from the PR branch
