### PR TITLE
Bumps version and updates CL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v2.1.0] 2024-07-02
+
 ### BREAKING CHANGES
 
 - Now uses Node version 20.12.2 and changes the base Docker image to `amazon/aws-lambda-nodejs:20`.
@@ -165,7 +167,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/nasa/cumulus-ecs-task/compare/v1.9.1...HEAD
+[Unreleased]: https://github.com/nasa/cumulus-ecs-task/compare/v2.1.0...HEAD
+[v2.1.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.9.1...v2.1.0
 [v1.9.1]: https://github.com/nasa/cumulus-ecs-task/compare/v1.9.0...v1.9.1
 [v1.9.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.8.0...v1.9.0
 [v1.8.0]: https://github.com/nasa/cumulus-ecs-task/compare/v1.7.0...v1.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.9.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cumulus/cumulus-ecs-task",
-      "version": "1.9.1",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.447.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-ecs-task",
-  "version": "1.9.1",
+  "version": "2.1.0",
   "description": "Run lambda functions in ECS",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Bumps version to 2.1.0 and updates the CL with the correct release sections. There is already a version 2.0.0 on ECR but not the CL so I went with 2.1.0.